### PR TITLE
Feature/entity manager stub

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,12 +5,6 @@ includes:
 parameters:
     ignoreErrors:
         -
-            message: '#Method .* has no return typehint specified\.#'
-            path: tests/Stubs
-        -
-            message: '#Method .* should return .* but return statement is missing\.#'
-            path: tests/Stubs
-        -
             message: '#Method .* return type has no value type specified in iterable type .*\.#'
             path: tests/Stubs
         -

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -22,3 +22,6 @@ parameters:
         -
             message: '#.* with no value type specified in iterable type Symfony\\Component\\Validator\\ConstraintViolationListInterface\.#'
             path: src/TestCases/
+        -
+            message: '#Variable method call on Eonx\\TestUtils\\Stubs\\BaseStub\.#'
+            path: tests/TestCases/StubTestCase.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,9 +11,6 @@ parameters:
             message: '#Method .* should return .* but return statement is missing\.#'
             path: tests/Stubs
         -
-            message: '#Method PHPUnit\\Framework\\Assert::assertThat\(\) has parameter \$value with no typehint specified\.#'
-            path: src/TestCases
-        -
             message: '#Method .* return type has no value type specified in iterable type .*\.#'
             path: tests/Stubs
         -

--- a/src/Stubs/BaseStub.php
+++ b/src/Stubs/BaseStub.php
@@ -106,8 +106,10 @@ abstract class BaseStub
             ));
         }
 
-        $methodResponses = $this->responses[$method] ?? [];
-        $response = \array_shift($methodResponses) ?? $default;
+        $response = $default;
+        if (\array_key_exists($method, $this->responses) === true) {
+            $response = \array_shift($this->responses[$method]) ?? $response;
+        }
 
         if ($response instanceof Throwable === true) {
             throw $response;

--- a/src/Stubs/BaseStub.php
+++ b/src/Stubs/BaseStub.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Eonx\TestUtils\Stubs;
 
 use Eonx\TestUtils\Exceptions\Stubs\NoResponsesConfiguredException;
+use RuntimeException;
 use Throwable;
 
 /**
@@ -70,7 +71,7 @@ abstract class BaseStub
     protected function getCalls(string $method): array
     {
         if (\preg_match('/^get(.*)Calls$/', $method, $matches) !== 1) {
-            throw new \RuntimeException(\sprintf(
+            throw new RuntimeException(\sprintf(
                 'Get method "%s" doesn\'t match required format of getMethodCalls()',
                 $method
             ));

--- a/src/Stubs/BaseStub.php
+++ b/src/Stubs/BaseStub.php
@@ -15,6 +15,14 @@ use Throwable;
 abstract class BaseStub
 {
     /**
+     * The constant used for the default value in returnOrThrowResponse to indicate
+     * the calling method did not provide a default.
+     *
+     * @const string
+     */
+    private const NOT_PROVIDED = '______NOT_PROVIDED';
+
+    /**
      * Storage of all calls made to stubbed methods.
      *
      * Calls are keyed by method name, and as a list of arrays where method names are keys.
@@ -87,25 +95,30 @@ abstract class BaseStub
     }
 
     /**
-     * Return the next item queued for response.
+     * Return the next item queued for response. If there is no response configured
+     * but a default is provided, it will be returned instead.
      *
      * This can be called with the following snippet:
-     *      return $this->returnOrThrowResponse(__FUNCTION__);
+     *      return $this->returnOrThrowResponse(__FUNCTION__, 'defaultValue');
      *
      * @param string $method The name of the original method to return the response for.
+     * @param mixed $default
      *
      * @return mixed A preprogrammed response.
+     *
+     * @noinspection ParameterDefaultValueIsNotNullInspection Non null default is required to operate
      */
-    protected function returnOrThrowResponse(string $method)
+    protected function returnOrThrowResponse(string $method, $default = self::NOT_PROVIDED)
     {
-        if (\array_key_exists($method, $this->responses) === false) {
+        if (\array_key_exists($method, $this->responses) === false &&
+            $default === self::NOT_PROVIDED) {
             throw new NoResponsesConfiguredException(\sprintf(
                 'No responses found in stub for method "%s"',
                 $method
             ));
         }
 
-        $response = \array_shift($this->responses[$method]);
+        $response = \array_shift($this->responses[$method]) ?? $default;
 
         if ($response instanceof Throwable === true) {
             throw $response;

--- a/src/Stubs/BaseStub.php
+++ b/src/Stubs/BaseStub.php
@@ -98,6 +98,9 @@ abstract class BaseStub
      */
     protected function returnOrThrowResponse(string $method, $default = self::NOT_PROVIDED)
     {
+        // If we dont have a default value provided, and there are no responses defined
+        // for this method, we will throw. For no throw behaviour, this method must be
+        // provided with a default value.
         if (\array_key_exists($method, $this->responses) === false &&
             $default === self::NOT_PROVIDED) {
             throw new NoResponsesConfiguredException(\sprintf(
@@ -107,14 +110,19 @@ abstract class BaseStub
         }
 
         $response = $default;
+
+        // If we have the method defined in the responses array, shift a response
+        // from that array (or use the default if we've run out of responses.
         if (\array_key_exists($method, $this->responses) === true) {
             $response = \array_shift($this->responses[$method]) ?? $response;
         }
 
+        // If the response is throwable, we're going to throw it instead.
         if ($response instanceof Throwable === true) {
             throw $response;
         }
 
+        // If we got here, and the response is still NOT_PROVIDED we'll return a null.
         return $response === self::NOT_PROVIDED
             ? null
             : $response;

--- a/src/Stubs/Vendor/Doctrine/ORM/EntityManagerStub.php
+++ b/src/Stubs/Vendor/Doctrine/ORM/EntityManagerStub.php
@@ -1,0 +1,411 @@
+<?php
+declare(strict_types=1);
+
+namespace Eonx\TestUtils\Stubs\Vendor\Doctrine\ORM;
+
+use Doctrine\Common\EventManager;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\Cache;
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Internal\Hydration\AbstractHydrator;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\NativeQuery;
+use Doctrine\ORM\Proxy\ProxyFactory;
+use Doctrine\ORM\Query;
+use Doctrine\ORM\Query\ResultSetMapping;
+use Doctrine\ORM\QueryBuilder;
+use Doctrine\ORM\UnitOfWork;
+use Doctrine\Persistence\Mapping\ClassMetadataFactory;
+use Eonx\TestUtils\Stubs\BaseStub;
+
+class EntityManagerStub extends BaseStub implements EntityManagerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function beginTransaction(): void
+    {
+        $this->saveCalls(__FUNCTION__, \get_defined_vars());
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function clear($objectName = null): void
+    {
+        $this->saveCalls(__FUNCTION__, \get_defined_vars());
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function close(): void
+    {
+        $this->saveCalls(__FUNCTION__, \get_defined_vars());
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function commit(): void
+    {
+        $this->saveCalls(__FUNCTION__, \get_defined_vars());
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function contains($object): bool
+    {
+        $this->saveCalls(__FUNCTION__, \get_defined_vars());
+
+        return $this->returnOrThrowResponse(__FUNCTION__, false);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @deprecated
+     */
+    public function copy($entity, $deep = null)
+    {
+        $this->saveCalls(__FUNCTION__, \get_defined_vars());
+
+        return $this->returnOrThrowResponse(__FUNCTION__, clone $entity);
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function createNamedNativeQuery($name): NativeQuery
+    {
+        $this->saveCalls(__FUNCTION__, \get_defined_vars());
+
+        return $this->returnOrThrowResponse(__FUNCTION__);
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function createNamedQuery($name): Query
+    {
+        $this->saveCalls(__FUNCTION__, \get_defined_vars());
+
+        return $this->returnOrThrowResponse(__FUNCTION__, new Query($this));
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function createNativeQuery($sql, ResultSetMapping $rsm): NativeQuery
+    {
+        $this->saveCalls(__FUNCTION__, \get_defined_vars());
+
+        return $this->returnOrThrowResponse(__FUNCTION__, new NativeQuery($this));
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function createQuery($dql = null): Query
+    {
+        $this->saveCalls(__FUNCTION__, \get_defined_vars());
+
+        return $this->returnOrThrowResponse(__FUNCTION__, new Query($this));
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function createQueryBuilder(): QueryBuilder
+    {
+        $this->saveCalls(__FUNCTION__, \get_defined_vars());
+
+        return $this->returnOrThrowResponse(__FUNCTION__, new QueryBuilder($this));
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @deprecated See EntityManager's deprecation.
+     */
+    public function detach($object): void
+    {
+        $this->saveCalls(__FUNCTION__, \get_defined_vars());
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function find($className, $id)
+    {
+        $this->saveCalls(__FUNCTION__, \get_defined_vars());
+
+        return $this->returnOrThrowResponse(__FUNCTION__, null);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function flush(): void
+    {
+        $this->saveCalls(__FUNCTION__, \get_defined_vars());
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function getCache(): ?Cache
+    {
+        $this->saveCalls(__FUNCTION__, \get_defined_vars());
+
+        return $this->returnOrThrowResponse(__FUNCTION__, null);
+    }
+
+    /**
+     * Not inherited due to weirdness with inheritdoc.
+     *
+     * @param mixed $className
+     *
+     * @return \Doctrine\ORM\Mapping\ClassMetadata
+     */
+    public function getClassMetadata($className): ClassMetadata
+    {
+        $this->saveCalls(__FUNCTION__, \get_defined_vars());
+
+        return $this->returnOrThrowResponse(__FUNCTION__, new ClassMetadata($className));
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfiguration(): Configuration
+    {
+        $this->saveCalls(__FUNCTION__, \get_defined_vars());
+
+        return $this->returnOrThrowResponse(__FUNCTION__);
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function getConnection(): Connection
+    {
+        $this->saveCalls(__FUNCTION__, \get_defined_vars());
+
+        return $this->returnOrThrowResponse(__FUNCTION__);
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function getEventManager(): EventManager
+    {
+        $this->saveCalls(__FUNCTION__, \get_defined_vars());
+
+        return $this->returnOrThrowResponse(__FUNCTION__);
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function getExpressionBuilder(): Query\Expr
+    {
+        $this->saveCalls(__FUNCTION__, \get_defined_vars());
+
+        return $this->returnOrThrowResponse(__FUNCTION__, new Query\Expr());
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function getFilters(): Query\FilterCollection
+    {
+        $this->saveCalls(__FUNCTION__, \get_defined_vars());
+
+        return $this->returnOrThrowResponse(__FUNCTION__, new Query\FilterCollection($this));
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @deprecated
+     */
+    public function getHydrator($hydrationMode): AbstractHydrator
+    {
+        $this->saveCalls(__FUNCTION__, \get_defined_vars());
+
+        return $this->returnOrThrowResponse(__FUNCTION__);
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function getMetadataFactory(): ClassMetadataFactory
+    {
+        $this->saveCalls(__FUNCTION__, \get_defined_vars());
+
+        return $this->returnOrThrowResponse(__FUNCTION__);
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function getPartialReference($entityName, $identifier)
+    {
+        $this->saveCalls(__FUNCTION__, \get_defined_vars());
+
+        return $this->returnOrThrowResponse(__FUNCTION__);
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function getProxyFactory(): ProxyFactory
+    {
+        $this->saveCalls(__FUNCTION__, \get_defined_vars());
+
+        return $this->returnOrThrowResponse(__FUNCTION__);
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function getReference($entityName, $id)
+    {
+        $this->saveCalls(__FUNCTION__, \get_defined_vars());
+
+        return $this->returnOrThrowResponse(__FUNCTION__);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @noinspection ReturnTypeCanBeDeclaredInspection
+     */
+    public function getRepository($className)
+    {
+        $this->saveCalls(__FUNCTION__, \get_defined_vars());
+
+        return $this->returnOrThrowResponse(__FUNCTION__);
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function getUnitOfWork(): UnitOfWork
+    {
+        $this->saveCalls(__FUNCTION__, \get_defined_vars());
+
+        return $this->returnOrThrowResponse(__FUNCTION__);
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function hasFilters(): bool
+    {
+        $this->saveCalls(__FUNCTION__, \get_defined_vars());
+
+        return $this->returnOrThrowResponse(__FUNCTION__, false);
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function initializeObject($obj): void
+    {
+        $this->saveCalls(__FUNCTION__, \get_defined_vars());
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function isFiltersStateClean(): bool
+    {
+        $this->saveCalls(__FUNCTION__, \get_defined_vars());
+
+        return $this->returnOrThrowResponse(__FUNCTION__, true);
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function isOpen(): bool
+    {
+        $this->saveCalls(__FUNCTION__, \get_defined_vars());
+
+        return $this->returnOrThrowResponse(__FUNCTION__, true);
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function lock($entity, $lockMode, $lockVersion = null): void
+    {
+        $this->saveCalls(__FUNCTION__, \get_defined_vars());
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function merge($object)
+    {
+        $this->saveCalls(__FUNCTION__, \get_defined_vars());
+
+        return $this->returnOrThrowResponse(__FUNCTION__, $object);
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function newHydrator($hydrationMode): AbstractHydrator
+    {
+        $this->saveCalls(__FUNCTION__, \get_defined_vars());
+
+        return $this->returnOrThrowResponse(__FUNCTION__);
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function persist($object): void
+    {
+        $this->saveCalls(__FUNCTION__, \get_defined_vars());
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function refresh($object): void
+    {
+        $this->saveCalls(__FUNCTION__, \get_defined_vars());
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function remove($object): void
+    {
+        $this->saveCalls(__FUNCTION__, \get_defined_vars());
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function rollback(): void
+    {
+        $this->saveCalls(__FUNCTION__, \get_defined_vars());
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function transactional($func)
+    {
+        $this->saveCalls(__FUNCTION__, \get_defined_vars());
+
+        return $this->returnOrThrowResponse(__FUNCTION__);
+    }
+}

--- a/src/Stubs/Vendor/Doctrine/ORM/EntityManagerStub.php
+++ b/src/Stubs/Vendor/Doctrine/ORM/EntityManagerStub.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Internal\Hydration\AbstractHydrator;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\ClassMetadataFactory as ORMClassMetadataFactory;
 use Doctrine\ORM\NativeQuery;
 use Doctrine\ORM\Proxy\ProxyFactory;
 use Doctrine\ORM\Query;
@@ -19,6 +20,9 @@ use Doctrine\ORM\UnitOfWork;
 use Doctrine\Persistence\Mapping\ClassMetadataFactory;
 use Eonx\TestUtils\Stubs\BaseStub;
 
+/**
+ * @SuppressWarnings(PHPMD) Interface is not under our control.
+ */
 class EntityManagerStub extends BaseStub implements EntityManagerInterface
 {
     /**
@@ -28,7 +32,7 @@ class EntityManagerStub extends BaseStub implements EntityManagerInterface
     {
         $this->saveCalls(__FUNCTION__, \get_defined_vars());
     }
-    
+
     /**
      * {@inheritdoc}
      */
@@ -36,7 +40,7 @@ class EntityManagerStub extends BaseStub implements EntityManagerInterface
     {
         $this->saveCalls(__FUNCTION__, \get_defined_vars());
     }
-    
+
     /**
      * {@inheritdoc}
      */
@@ -62,7 +66,7 @@ class EntityManagerStub extends BaseStub implements EntityManagerInterface
 
         return $this->returnOrThrowResponse(__FUNCTION__, false);
     }
-
+    
     /**
      * {@inheritdoc}
      *
@@ -74,7 +78,7 @@ class EntityManagerStub extends BaseStub implements EntityManagerInterface
 
         return $this->returnOrThrowResponse(__FUNCTION__, clone $entity);
     }
-    
+
     /**
      * {@inheritdoc}
      */
@@ -124,7 +128,7 @@ class EntityManagerStub extends BaseStub implements EntityManagerInterface
 
         return $this->returnOrThrowResponse(__FUNCTION__, new QueryBuilder($this));
     }
-
+    
     /**
      * {@inheritdoc}
      *
@@ -134,7 +138,7 @@ class EntityManagerStub extends BaseStub implements EntityManagerInterface
     {
         $this->saveCalls(__FUNCTION__, \get_defined_vars());
     }
-    
+
     /**
      * {@inheritdoc}
      */
@@ -144,7 +148,7 @@ class EntityManagerStub extends BaseStub implements EntityManagerInterface
 
         return $this->returnOrThrowResponse(__FUNCTION__, null);
     }
-
+    
     /**
      * {@inheritdoc}
      */
@@ -152,7 +156,7 @@ class EntityManagerStub extends BaseStub implements EntityManagerInterface
     {
         $this->saveCalls(__FUNCTION__, \get_defined_vars());
     }
-    
+
     /**
      * {@inheritdoc}
      */
@@ -184,7 +188,7 @@ class EntityManagerStub extends BaseStub implements EntityManagerInterface
     {
         $this->saveCalls(__FUNCTION__, \get_defined_vars());
 
-        return $this->returnOrThrowResponse(__FUNCTION__);
+        return $this->returnOrThrowResponse(__FUNCTION__, new Configuration());
     }
     
     /**
@@ -204,7 +208,7 @@ class EntityManagerStub extends BaseStub implements EntityManagerInterface
     {
         $this->saveCalls(__FUNCTION__, \get_defined_vars());
 
-        return $this->returnOrThrowResponse(__FUNCTION__);
+        return $this->returnOrThrowResponse(__FUNCTION__, new EventManager());
     }
     
     /**
@@ -230,6 +234,8 @@ class EntityManagerStub extends BaseStub implements EntityManagerInterface
     /**
      * {@inheritdoc}
      *
+     * @codeCoverageIgnore
+     *
      * @deprecated
      */
     public function getHydrator($hydrationMode): AbstractHydrator
@@ -246,7 +252,7 @@ class EntityManagerStub extends BaseStub implements EntityManagerInterface
     {
         $this->saveCalls(__FUNCTION__, \get_defined_vars());
 
-        return $this->returnOrThrowResponse(__FUNCTION__);
+        return $this->returnOrThrowResponse(__FUNCTION__, new ORMClassMetadataFactory());
     }
     
     /**
@@ -261,6 +267,8 @@ class EntityManagerStub extends BaseStub implements EntityManagerInterface
     
     /**
      * {@inheritdoc}
+     *
+     * @codeCoverageIgnore
      */
     public function getProxyFactory(): ProxyFactory
     {
@@ -298,7 +306,7 @@ class EntityManagerStub extends BaseStub implements EntityManagerInterface
     {
         $this->saveCalls(__FUNCTION__, \get_defined_vars());
 
-        return $this->returnOrThrowResponse(__FUNCTION__);
+        return $this->returnOrThrowResponse(__FUNCTION__, new UnitOfWork($this));
     }
     
     /**
@@ -359,6 +367,8 @@ class EntityManagerStub extends BaseStub implements EntityManagerInterface
     
     /**
      * {@inheritdoc}
+     *
+     * @codeCoverageIgnore
      */
     public function newHydrator($hydrationMode): AbstractHydrator
     {

--- a/src/TestCases/Traits/AssertTrait.php
+++ b/src/TestCases/Traits/AssertTrait.php
@@ -14,7 +14,6 @@ use Eonx\TestUtils\Constraints\ResponseNoException;
 use Eonx\TestUtils\Constraints\SymfonyConstraintViolation;
 use Eonx\TestUtils\Helpers\Interfaces\ClientStubInterface;
 use LoyaltyCorp\RequestHandlers\Request\RequestObjectInterface;
-use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\Constraint\IsIdentical;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Validator\ConstraintViolationListInterface;

--- a/src/TestCases/UnitTestCase.php
+++ b/src/TestCases/UnitTestCase.php
@@ -5,6 +5,9 @@ namespace Eonx\TestUtils\TestCases;
 
 use Eonx\TestUtils\TestCases\Traits\AssertTrait;
 
+/**
+ * @SuppressWarnings(PHPMD.NumberOfChildren)
+ */
 abstract class UnitTestCase extends TestCase
 {
     use AssertTrait;

--- a/tests/Stubs/Stubs/BaseStubStub.php
+++ b/tests/Stubs/Stubs/BaseStubStub.php
@@ -17,7 +17,7 @@ class BaseStubStub extends BaseStub
      */
     public function getExampleCalls(): array
     {
-        return $this->getCalls(__FUNCTION__);
+        return $this->getCalls('example');
     }
 
     /**
@@ -27,7 +27,7 @@ class BaseStubStub extends BaseStub
      */
     public function getBadness(): array
     {
-        return $this->getCalls(__FUNCTION__);
+        return $this->getCalls('badness');
     }
 
     /**
@@ -46,6 +46,8 @@ class BaseStubStub extends BaseStub
      * @param string $arg
      *
      * @return string|null
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter) Not unused
      */
     public function example(string $arg): ?string
     {

--- a/tests/TestCases/StubTestCase.php
+++ b/tests/TestCases/StubTestCase.php
@@ -20,7 +20,8 @@ abstract class StubTestCase extends UnitTestCase
     abstract public function getMethodExpectations(): iterable;
 
     /**
-     * Data provider for testStubMethods
+     * Data provider for testStubMethods.
+     *
      * @return mixed[]
      */
     public function getStubMethodData(): iterable
@@ -64,7 +65,7 @@ abstract class StubTestCase extends UnitTestCase
      * @param string $method
      * @param mixed $returnValue
      *
-     * @return BaseStub
+     * @return \Eonx\TestUtils\Stubs\BaseStub
      */
     protected function createStubForTest(string $method, $returnValue): BaseStub
     {

--- a/tests/TestCases/StubTestCase.php
+++ b/tests/TestCases/StubTestCase.php
@@ -1,0 +1,79 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Eonx\TestUtils\TestCases;
+
+use Eonx\TestUtils\Stubs\BaseStub;
+use Eonx\TestUtils\TestCases\UnitTestCase;
+
+/**
+ * @coversNothing
+ */
+abstract class StubTestCase extends UnitTestCase
+{
+    /**
+     * Returns an array of  expectations for methods of a stub that are asserted
+     * against the stub methods to ensure they are configured properly.
+     *
+     * @return mixed[]
+     */
+    abstract public function getMethodExpectations(): iterable;
+
+    /**
+     * Data provider for testStubMethods
+     * @return mixed[]
+     */
+    public function getStubMethodData(): iterable
+    {
+        yield from $this->getMethodExpectations();
+    }
+
+    /**
+     * Returns the stub class to be tested.
+     *
+     * @phpstan-return class-string
+     *
+     * @return string
+     */
+    abstract public function getStubClass(): string;
+
+    /**
+     * Tests that stub methods are correctly defined.
+     *
+     * @param string $method
+     * @param mixed[] $inputArgs
+     * @param mixed $returnValue
+     *
+     * @return void
+     *
+     * @dataProvider getStubMethodData
+     */
+    public function testStubMethods(string $method, array $inputArgs, $returnValue): void
+    {
+        $stub = $this->createStubForTest($method, $returnValue);
+
+        $result = $stub->$method(...\array_values($inputArgs));
+
+        self::assertSame($returnValue, $result);
+        self::assertEqualsCanonicalizing([$inputArgs], $stub->getCalls($method));
+    }
+
+    /**
+     * Returns a stub configured a response for a method.
+     *
+     * @param string $method
+     * @param mixed $returnValue
+     *
+     * @return BaseStub
+     */
+    protected function createStubForTest(string $method, $returnValue): BaseStub
+    {
+        $class = $this->getStubClass();
+
+        return new $class([
+            $method => [
+                $returnValue
+            ]
+        ]);
+    }
+}

--- a/tests/Unit/Stubs/BaseStubTest.php
+++ b/tests/Unit/Stubs/BaseStubTest.php
@@ -11,6 +11,8 @@ use Tests\Eonx\TestUtils\Stubs\Stubs\BaseStubStub;
 
 /**
  * @covers \Eonx\TestUtils\Stubs\BaseStub
+ *
+ * @SuppressWarnings(PHPMD.EmptyCatchBlock) Required to test
  */
 class BaseStubTest extends UnitTestCase
 {
@@ -38,7 +40,6 @@ class BaseStubTest extends UnitTestCase
         $first = $stub->example('in-1');
         $second = $stub->example('in-2');
 
-
         $exception = null;
         try {
             $stub->example('in-3');
@@ -63,21 +64,6 @@ class BaseStubTest extends UnitTestCase
         $expectedCalls = [];
 
         self::assertSame($expectedCalls, $stub->getExampleCalls());
-    }
-
-    /**
-     * Tests an incorrectly configured get<Method>Calls function.
-     *
-     * @return void
-     */
-    public function testBadGetCallsMethod(): void
-    {
-        $stub = new BaseStubStub();
-
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Get method "getBadness" doesn\'t match required format of getMethodCalls()');
-
-        $stub->getBadness();
     }
 
     /**

--- a/tests/Unit/Stubs/BaseStubTest.php
+++ b/tests/Unit/Stubs/BaseStubTest.php
@@ -6,7 +6,6 @@ namespace Tests\Eonx\TestUtils\Unit\Stubs;
 use Eonx\TestUtils\Exceptions\Stubs\NoResponsesConfiguredException;
 use Eonx\TestUtils\TestCases\UnitTestCase;
 use Exception;
-use RuntimeException;
 use Tests\Eonx\TestUtils\Stubs\Stubs\BaseStubStub;
 
 /**

--- a/tests/Unit/Stubs/Vendor/Doctrine/ORM/EntityManagerStubTest.php
+++ b/tests/Unit/Stubs/Vendor/Doctrine/ORM/EntityManagerStubTest.php
@@ -1,0 +1,294 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Eonx\TestUtils\Unit\Stubs\Vendor\Doctrine\ORM;
+
+use Doctrine\Common\EventManager;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\PDOSqlite\Driver;
+use Doctrine\ORM\Cache\DefaultCache;
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\Internal\Hydration\SimpleObjectHydrator;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\ClassMetadataFactory;
+use Doctrine\ORM\NativeQuery;
+use Doctrine\ORM\Proxy\ProxyFactory;
+use Doctrine\ORM\Query;
+use Doctrine\ORM\QueryBuilder;
+use Doctrine\ORM\UnitOfWork;
+use Eonx\TestUtils\Stubs\Vendor\Doctrine\ORM\EntityManagerStub;
+use stdClass;
+use Tests\Eonx\TestUtils\TestCases\StubTestCase;
+
+/**
+ * @covers \Eonx\TestUtils\Stubs\Vendor\Doctrine\ORM\EntityManagerStub
+ */
+class EntityManagerStubTest extends StubTestCase
+{
+    /**
+     * {@inheritdoc}
+     * @throws \Doctrine\DBAL\DBALException
+     */
+    public function getMethodExpectations(): iterable
+    {
+        $entityManager = new EntityManagerStub();
+
+        yield 'beginTransaction' => [
+            'method' => 'beginTransaction',
+            'args' => [],
+            'return' => null
+        ];
+
+        yield 'clear' => [
+            'method' => 'clear',
+            'args' => ['objectName' => 'objectName'],
+            'return' => null
+        ];
+
+        yield 'close' => [
+            'method' => 'close',
+            'args' => [],
+            'return' => null
+        ];
+
+        yield 'commit' => [
+            'method' => 'commit',
+            'args' => [],
+            'return' => null
+        ];
+
+        yield 'contains' => [
+            'method' => 'contains',
+            'args' => ['object' => new stdClass()],
+            'return' => false
+        ];
+
+        $stdClass = new stdClass();
+
+        yield 'copy' => [
+            'method' => 'copy',
+            'args' => [
+                'object' => $stdClass,
+                'deep' => false
+            ],
+            'return' => $stdClass
+        ];
+
+        yield 'createNamedNativeQuery' => [
+            'method' => 'createNamedNativeQuery',
+            'args' => ['name' => 'name'],
+            'return' => new NativeQuery($entityManager)
+        ];
+
+        yield 'createNamedQuery' => [
+            'method' => 'createNamedQuery',
+            'args' => ['name' => 'name'],
+            'return' => new Query($entityManager)
+        ];
+
+        yield 'createNativeQuery' => [
+            'method' => 'createNativeQuery',
+            'args' => [
+                'sql' => 'sql',
+                'rsm' => new Query\ResultSetMapping()
+            ],
+            'return' => new NativeQuery($entityManager)
+        ];
+
+        yield 'createQuery' => [
+            'method' => 'createQuery',
+            'args' => [
+                'dql' => 'dql',
+            ],
+            'return' => new Query($entityManager)
+        ];
+
+        yield 'createQueryBuilder' => [
+            'method' => 'createQueryBuilder',
+            'args' => [],
+            'return' => new QueryBuilder($entityManager)
+        ];
+
+        yield 'detach' => [
+            'method' => 'detach',
+            'args' => [
+                'object' => new stdClass()
+            ],
+            'return' => null
+        ];
+
+        yield 'find' => [
+            'method' => 'find',
+            'args' => [
+                'className' => stdClass::class,
+                'id' => 5
+            ],
+            'return' => null
+        ];
+
+        yield 'flush' => [
+            'method' => 'flush',
+            'args' => [],
+            'return' => null
+        ];
+
+        yield 'getCache' => [
+            'method' => 'getCache',
+            'args' => [],
+            'return' => null
+        ];
+
+        yield 'getClassMetadata' => [
+            'method' => 'getClassMetadata',
+            'args' => ['className' => stdClass::class],
+            'return' => new ClassMetadata(stdClass::class)
+        ];
+
+        yield 'getConfiguration' => [
+            'method' => 'getConfiguration',
+            'args' => [],
+            'return' => new Configuration()
+        ];
+
+        yield 'getConnection' => [
+            'method' => 'getConnection',
+            'args' => [],
+            'return' => new Connection([], new Driver())
+        ];
+
+        yield 'getEventManager' => [
+            'method' => 'getEventManager',
+            'args' => [],
+            'return' => new EventManager()
+        ];
+
+        yield 'getExpressionBuilder' => [
+            'method' => 'getExpressionBuilder',
+            'args' => [],
+            'return' => new Query\Expr()
+        ];
+
+        yield 'getFilters' => [
+            'method' => 'getFilters',
+            'args' => [],
+            'return' => new Query\FilterCollection($entityManager)
+        ];
+
+        yield 'getMetadataFactory' => [
+            'method' => 'getMetadataFactory',
+            'args' => [],
+            'return' => new ClassMetadataFactory()
+        ];
+
+        yield 'getPartialReference' => [
+            'method' => 'getPartialReference',
+            'args' => [
+                'entityName' => stdClass::class,
+                'identifier' => 7
+            ],
+            'return' => new stdClass()
+        ];
+
+        yield 'getReference' => [
+            'method' => 'getReference',
+            'args' => [
+                'entityName' => stdClass::class,
+                'id' => 7
+            ],
+            'return' => new stdClass()
+        ];
+
+        yield 'getRepository' => [
+            'method' => 'getRepository',
+            'args' => [
+                'className' => stdClass::class,
+            ],
+            'return' => new EntityRepository($entityManager, new ClassMetadata(stdClass::class))
+        ];
+
+        yield 'getUnitOfWork' => [
+            'method' => 'getUnitOfWork',
+            'args' => [],
+            'return' => new UnitOfWork($entityManager)
+        ];
+
+        yield 'hasFilters' => [
+            'method' => 'hasFilters',
+            'args' => [],
+            'return' => false
+        ];
+
+        yield 'initializeObject' => [
+            'method' => 'initializeObject',
+            'args' => ['obj' => new stdClass()],
+            'return' => null
+        ];
+
+        yield 'isFiltersStateClean' => [
+            'method' => 'isFiltersStateClean',
+            'args' => [],
+            'return' => true
+        ];
+
+        yield 'isOpen' => [
+            'method' => 'isOpen',
+            'args' => [],
+            'return' => true
+        ];
+
+        yield 'lock' => [
+            'method' => 'lock',
+            'args' => [
+                'entity' => new stdClass(),
+                'lockMode' => 'purple',
+                'lockVersion' => 69
+            ],
+            'return' => null
+        ];
+
+        yield 'merge' => [
+            'method' => 'merge',
+            'args' => [
+                'object' => $stdClass
+            ],
+            'return' => $stdClass
+        ];
+
+        yield 'persist' => [
+            'method' => 'persist',
+            'args' => [
+                'object' => $stdClass
+            ],
+            'return' => null
+        ];
+
+        yield 'remove' => [
+            'method' => 'remove',
+            'args' => [
+                'object' => $stdClass
+            ],
+            'return' => null
+        ];
+
+        yield 'rollback' => [
+            'method' => 'rollback',
+            'args' => [],
+            'return' => null
+        ];
+
+        yield 'transactional' => [
+            'method' => 'transactional',
+            'args' => ['func' => static function () {}],
+            'return' => null
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getStubClass(): string
+    {
+        return EntityManagerStub::class;
+    }
+}

--- a/tests/Unit/Stubs/Vendor/Doctrine/ORM/EntityManagerStubTest.php
+++ b/tests/Unit/Stubs/Vendor/Doctrine/ORM/EntityManagerStubTest.php
@@ -6,14 +6,11 @@ namespace Tests\Eonx\TestUtils\Unit\Stubs\Vendor\Doctrine\ORM;
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\PDOSqlite\Driver;
-use Doctrine\ORM\Cache\DefaultCache;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityRepository;
-use Doctrine\ORM\Internal\Hydration\SimpleObjectHydrator;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
 use Doctrine\ORM\NativeQuery;
-use Doctrine\ORM\Proxy\ProxyFactory;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\ORM\UnitOfWork;
@@ -23,11 +20,15 @@ use Tests\Eonx\TestUtils\TestCases\StubTestCase;
 
 /**
  * @covers \Eonx\TestUtils\Stubs\Vendor\Doctrine\ORM\EntityManagerStub
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects) Required to test
+ * @SuppressWarnings(PHPMD.ExcessiveMethodLength) Required to test
  */
 class EntityManagerStubTest extends StubTestCase
 {
     /**
      * {@inheritdoc}
+     *
      * @throws \Doctrine\DBAL\DBALException
      */
     public function getMethodExpectations(): iterable
@@ -279,7 +280,8 @@ class EntityManagerStubTest extends StubTestCase
 
         yield 'transactional' => [
             'method' => 'transactional',
-            'args' => ['func' => static function () {}],
+            'args' => ['func' => static function (): void {
+            }],
             'return' => null
         ];
     }


### PR DESCRIPTION
- Changes BaseStub's getCalls method to be public - accepting a string of the method name. Done because duplicating getters for calls for every method in the EntityManagerStub doesnt make sense.
- Added ability to set default values for returns which are used if no configured method returns are found or have run out
- Add EntityManagerStub