### PR TITLE
Add callable/continuous return values for BaseStub

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "eonx-com/apiformats": "^1.0",
     "eonx-com/requesthandlers": "^1.2",
     "eonx-com/search": "^2.0",
-    "eonx-com/standards": "^0.2.2",
+    "eonx-com/standards": "^0.3",
     "phpmd/phpmd": "^2.7",
     "phpstan/phpstan": "^0.12.3",
     "phpstan/phpstan-phpunit": "^0.12",

--- a/tests/Stubs/Stubs/BaseStubStub.php
+++ b/tests/Stubs/Stubs/BaseStubStub.php
@@ -55,4 +55,19 @@ class BaseStubStub extends BaseStub
 
         return $this->returnOrThrowResponse(__FUNCTION__);
     }
+
+    /**
+     * Test for a callable response.
+     *
+     * @param string $arg1
+     * @param int $arg2
+     *
+     * @return float
+     */
+    public function callable(string $arg1, int $arg2): float
+    {
+        $this->saveCalls(__FUNCTION__, \get_defined_vars());
+
+        return $this->returnOrThrowResponse(__FUNCTION__, null, \func_get_args());
+    }
 }

--- a/tests/Unit/Stubs/BaseStubTest.php
+++ b/tests/Unit/Stubs/BaseStubTest.php
@@ -52,6 +52,49 @@ class BaseStubTest extends UnitTestCase
     }
 
     /**
+     * Tests a callable response
+     *
+     * @return void
+     */
+    public function testStubCallable(): void
+    {
+        $stub = new BaseStubStub([
+            'callable' => static function (string $arg1, int $arg2): float {
+                return \mb_strlen($arg1) * $arg2 / 100;
+            }
+        ]);
+
+        $expectedCalls = [
+            ['arg1' => 'long', 'arg2' => 56]
+        ];
+
+        $result = $stub->callable('long', 56);
+
+        self::assertSame(2.24, $result);
+        self::assertSame($expectedCalls, $stub->getCalls('callable'));
+    }
+
+    /**
+     * Tests a callable response
+     *
+     * @return void
+     */
+    public function testScalarAlwaysRespond(): void
+    {
+        $stub = new BaseStubStub([
+            'example' => 'out'
+        ]);
+
+        $result = $stub->example('in');
+        $result2 = $stub->example('in');
+        $result3 = $stub->example('in');
+
+        self::assertSame('out', $result);
+        self::assertSame('out', $result2);
+        self::assertSame('out', $result3);
+    }
+
+    /**
      * Tests typical stub operation.
      *
      * @return void


### PR DESCRIPTION
- If you supply a non array into a BaseStub response array for a method, it will be used for every single call instead of a stack
- If you pass a callable inside the stack (or as above, just the callable not in an array) it will be called with method arguments