### PR TITLE
Add a matching stub that will search for a return value

### DIFF
--- a/src/Stubs/BaseStub.php
+++ b/src/Stubs/BaseStub.php
@@ -101,6 +101,37 @@ abstract class BaseStub
     }
 
     /**
+     * Finds a response to use for the method.
+     *
+     * @param string $method
+     * @param mixed[] $args
+     * @param mixed $default
+     *
+     * @return mixed
+     *
+     * @noinspection PhpMethodNamingConventionInspection
+     */
+    protected function _getResponseFor(string $method, array $args, $default)
+    {
+        // If we dont have a response configured, we have a default - lets return it.
+        if (\array_key_exists($method, $this->responses) === false) {
+            return $default;
+        }
+
+        // If we have an array, assume it is a stack of responses and shift the first
+        // response to be returned. If it is an empty array, return the default value.
+        if (\is_array($this->responses[$method]) === true) {
+            // If there is no responses configured, return the default.
+            return \count($this->responses[$method]) === 0
+                ? $default
+                : \array_shift($this->responses[$method]);
+        }
+
+        // If we got here, the response for $method is a non array value, return it as is.
+        return $this->responses[$method];
+    }
+
+    /**
      * Performs a stub call - recording the fact the method was called with args and
      * then returning or throwing a value. This method will work fine for void return
      * methods where you still call this method but do not return its value.
@@ -164,36 +195,6 @@ abstract class BaseStub
     }
 
     /**
-     * Finds a response to use for the method.
-     *
-     * @param string $method
-     * @param mixed $default
-     *
-     * @return mixed
-     */
-    private function getResponseFor(string $method, $default)
-    {
-        // If we dont have a response configured, we have a default - lets return it.
-        if (\array_key_exists($method, $this->responses) === false) {
-            return $default;
-        }
-
-        // If we have an array, assume it is a stack of responses and shift the first
-        // response to be returned. If it is an empty array, return the default value.
-        if (\is_array($this->responses[$method]) === true) {
-            // We dont have any values, return default.
-            if (\count($this->responses[$method]) === 0) {
-                return $default;
-            }
-
-            return \array_shift($this->responses[$method]);
-        }
-
-        // If we got here, the response for $method is a non array value, return it as is.
-        return $this->responses[$method];
-    }
-
-    /**
      * Resolves a response if one exists and throws or returns it.
      *
      * @param string $method
@@ -204,7 +205,7 @@ abstract class BaseStub
      */
     private function handleResponse(string $method, array $args, $default)
     {
-        $response = $this->getResponseFor($method, $default);
+        $response = $this->_getResponseFor($method, $args, $default);
 
         // If we got a callable and we were passed the method args, call it to resolve the
         // response.

--- a/src/Stubs/ExpectedCall.php
+++ b/src/Stubs/ExpectedCall.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace Eonx\TestUtils\Stubs;
+
+final class ExpectedCall
+{
+    /**
+     * @var mixed[]
+     */
+    private $args;
+
+    /**
+     * @var mixed
+     */
+    private $returnValue;
+
+    /**
+     * Constructor
+     *
+     * @param mixed[] $args
+     * @param mixed $returnValue
+     */
+    public function __construct(array $args, $returnValue)
+    {
+        $this->args = $args;
+        $this->returnValue = $returnValue;
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function getArgs(): array
+    {
+        return $this->args;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getReturnValue()
+    {
+        return $this->returnValue;
+    }
+}

--- a/src/Stubs/MatchingStub.php
+++ b/src/Stubs/MatchingStub.php
@@ -1,0 +1,73 @@
+<?php
+declare(strict_types=1);
+
+namespace Eonx\TestUtils\Stubs;
+
+use SebastianBergmann\Comparator\ArrayComparator;
+use SebastianBergmann\Comparator\ComparisonFailure;
+use SebastianBergmann\Comparator\Factory;
+
+/**
+ * A base stub that adds the capability of having a return map that will
+ * find method return values based on the arguments passed to the stub.
+ *
+ * @coversNothing
+ */
+abstract class MatchingStub extends BaseStub
+{
+    /**
+     * Stores arrays of ExpectedCall objects grouped by method as the key.
+     *
+     * @var ExpectedCall[][]
+     */
+    private $responses;
+
+    /**
+     * Constructor
+     *
+     * @param ExpectedCall[][]|null $responses
+     */
+    public function __construct(?array $responses = null)
+    {
+        $this->responses = $responses ?? [];
+
+        parent::__construct([]);
+    }
+
+    /**
+     * Finds a response to use for the method.
+     *
+     * @param string $method
+     * @param mixed[] $args
+     * @param mixed $default
+     *
+     * @return mixed
+     *
+     * @noinspection PhpMethodNamingConventionInspection PhpMissingParentCallCommonInspection
+     */
+    protected function _getResponseFor(string $method, array $args, $default)
+    {
+        // If we dont have a response configured, we have a default - lets return it.
+        if (\array_key_exists($method, $this->responses) === false) {
+            return $default;
+        }
+
+        $arrayComparator = new ArrayComparator();
+        $arrayComparator->setFactory(Factory::getInstance());
+
+        // Attempt to find an ExpectedCall that matches the args we received otherwise
+        // return the default value. Uses the same semantics as the assertEquals array
+        // behavior.
+        foreach ($this->responses[$method] as $potentialMethod) {
+            try {
+                $arrayComparator->assertEquals($potentialMethod->getArgs(), $args);
+            } catch (ComparisonFailure $exception) {
+                continue;
+            }
+
+            return $potentialMethod->getReturnValue();
+        }
+
+        return $default;
+    }
+}


### PR DESCRIPTION
This should theoretically allow a stub to accept an array of ExpectedCall objects that define expected args and the return value for those args.

```
        $preprocessor = new PreProcessorStub([
            'preprocess' => [
                new ExpectedCall(
                    [
                        'request' => $request
                    ],
                    $responseDtos
                )
            ]
        ]);
```