### PR TITLE
ScalarComparator

### DIFF
--- a/src/Comparators/ScalarComparator.php
+++ b/src/Comparators/ScalarComparator.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+namespace Eonx\TestUtils\Comparators;
+
+use SebastianBergmann\Comparator\ComparisonFailure;
+use SebastianBergmann\Comparator\ScalarComparator as BaseScalarComparator;
+
+/**
+ * A custom scalar comparator that allows assertEquals on an array to then do assertSame
+ * comparisons on scalar values.
+ */
+class ScalarComparator extends BaseScalarComparator
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function assertEquals($expected, $actual, $delta = 0.0, $canonicalize = false, $ignoreCase = false)
+    {
+        $expectedToCompare = $expected;
+        $actualToCompare   = $actual;
+
+        if ($expectedToCompare !== $actualToCompare) {
+            throw new ComparisonFailure(
+                $expected,
+                $actual,
+                // no diff is required
+                '',
+                '',
+                false,
+                \sprintf(
+                    'Failed asserting that %s matches expected %s.',
+                    $this->exporter->export($actual),
+                    $this->exporter->export($expected)
+                )
+            );
+        }
+    }
+}

--- a/src/Comparators/ScalarComparator.php
+++ b/src/Comparators/ScalarComparator.php
@@ -15,12 +15,9 @@ class ScalarComparator extends BaseScalarComparator
     /**
      * {@inheritdoc}
      */
-    public function assertEquals($expected, $actual, $delta = 0.0, $canonicalize = false, $ignoreCase = false)
+    public function assertEquals($expected, $actual, $delta = null, $canonicalize = null, $ignoreCase = null): void
     {
-        $expectedToCompare = $expected;
-        $actualToCompare   = $actual;
-
-        if ($expectedToCompare !== $actualToCompare) {
+        if ($expected !== $actual) {
             throw new ComparisonFailure(
                 $expected,
                 $actual,

--- a/src/Constraints/JsonSameAsArray.php
+++ b/src/Constraints/JsonSameAsArray.php
@@ -8,7 +8,6 @@ use Eonx\TestUtils\Helpers\ApplyFuzziness;
 use Eonx\TestUtils\Helpers\Interfaces\ApplyFuzzinessInterface;
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\Constraint\IsEqual;
-use PHPUnit\Framework\Constraint\IsIdentical;
 use PHPUnit\Framework\Constraint\IsJson;
 use SebastianBergmann\Comparator\Factory;
 
@@ -66,9 +65,9 @@ class JsonSameAsArray extends Constraint
         $scalarComparator = new ScalarComparator();
         Factory::getInstance()->register($scalarComparator);
 
-        $isSame = new IsEqual($this->expected);
+        $isEqual = new IsEqual($this->expected);
 
-        $result = $isSame->evaluate($fuzzyActual, $description, $returnResult);
+        $result = $isEqual->evaluate($fuzzyActual, $description, $returnResult);
 
         Factory::getInstance()->unregister($scalarComparator);
 

--- a/src/Constraints/JsonSameAsArray.php
+++ b/src/Constraints/JsonSameAsArray.php
@@ -3,11 +3,14 @@ declare(strict_types=1);
 
 namespace Eonx\TestUtils\Constraints;
 
+use Eonx\TestUtils\Comparators\ScalarComparator;
 use Eonx\TestUtils\Helpers\ApplyFuzziness;
 use Eonx\TestUtils\Helpers\Interfaces\ApplyFuzzinessInterface;
 use PHPUnit\Framework\Constraint\Constraint;
+use PHPUnit\Framework\Constraint\IsEqual;
 use PHPUnit\Framework\Constraint\IsIdentical;
 use PHPUnit\Framework\Constraint\IsJson;
+use SebastianBergmann\Comparator\Factory;
 
 class JsonSameAsArray extends Constraint
 {
@@ -59,8 +62,17 @@ class JsonSameAsArray extends Constraint
             ':fuzzy:'
         );
 
-        $isSame = new IsIdentical($this->expected);
-        return $isSame->evaluate($fuzzyActual, $description, $returnResult);
+        // Override IsEqual scalar comparisons to be strong.
+        $scalarComparator = new ScalarComparator();
+        Factory::getInstance()->register($scalarComparator);
+
+        $isSame = new IsEqual($this->expected);
+
+        $result = $isSame->evaluate($fuzzyActual, $description, $returnResult);
+
+        Factory::getInstance()->unregister($scalarComparator);
+
+        return $result;
     }
 
     /**

--- a/tests/Unit/Comparators/ScalarComparatorTest.php
+++ b/tests/Unit/Comparators/ScalarComparatorTest.php
@@ -1,0 +1,131 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Eonx\TestUtils\Unit\Comparators;
+
+use Eonx\TestUtils\Comparators\ScalarComparator;
+use Eonx\TestUtils\TestCases\UnitTestCase;
+use SebastianBergmann\Comparator\ComparisonFailure;
+use SebastianBergmann\Comparator\Factory;
+
+class ScalarComparatorTest extends UnitTestCase
+{
+    /**
+     * Failures that the comparator should fail.
+     *
+     * @return mixed[]
+     */
+    public function getScalarFailureTestData(): iterable
+    {
+        return [
+            ['1', 1],
+            ['10', 10],
+            ['', false],
+            ['1', true],
+            [1, true],
+            [0, false],
+            [0.1, '0.1'],
+            [false, null],
+            // Taken from original Scalar Comparator tests
+            ['string', 'other string'],
+            ['string', 'STRING'],
+            ['STRING', 'string'],
+            ['string', 'other string'],
+            ['9E6666666', '9E7777777'],
+            [0, 'Foobar'],
+            ['Foobar', 0],
+            ['10', 25],
+            ['1', false],
+            ['', true],
+            [false, true],
+            [true, false],
+            [null, true],
+            [0, true],
+            ['0', '0.0'],
+            ['0.', '0.0'],
+            ['0e1', '0e2'],
+            ["\n\n\n0.0", '                   0.'],
+            ['0.0', '25e-10000'],
+        ];
+    }
+
+    /**
+     * Failures that the comparator should succeed.
+     *
+     * @return mixed[]
+     */
+    public function getScalarSuccessTestData(): iterable
+    {
+        return [
+            [false, false],
+            [true, true],
+            [null, null],
+            ['string', 'string'],
+            [1, 1],
+            [1.5, 1.5],
+        ];
+    }
+
+    /**
+     * Tests that when the comparator factory has our scalar comparator that assert equals behaviour
+     * relating to arrays changes.
+     *
+     * @return void
+     */
+    public function testArrayAssertion(): void
+    {
+        $comparator = new ScalarComparator();
+
+        Factory::getInstance()->register($comparator);
+
+        $expected = ['thing' => 1];
+        $actual = ['thing' => '1'];
+
+        self::assertNotEquals($expected, $actual);
+
+        Factory::getInstance()->unregister($comparator);
+
+        self::assertEquals($expected, $actual);
+    }
+
+    /**
+     * Tests that the comparator fails on conditions.
+     *
+     * @param mixed $expected
+     * @param mixed $actual
+     *
+     * @return void
+     *
+     * @dataProvider getScalarFailureTestData
+     */
+    public function testScalarComparsonFailure($expected, $actual): void
+    {
+        $comparator = new ScalarComparator();
+
+        $this->expectException(ComparisonFailure::class);
+
+        /** @noinspection PhpUnitTestsInspection */
+        $comparator->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Tests that the comparator succeeds on conditions.
+     *
+     * @param mixed $expected
+     * @param mixed $actual
+     *
+     * @return void
+     *
+     * @dataProvider getScalarSuccessTestData
+     */
+    public function testScalarComparsonSuccess($expected, $actual): void
+    {
+        $comparator = new ScalarComparator();
+
+        /** @noinspection PhpUnitTestsInspection */
+        $comparator->assertEquals($expected, $actual);
+
+        // Comparator doesnt throw.
+        self::addToAssertionCount(1);
+    }
+}

--- a/tests/Unit/Constraints/JsonSameAsArrayTest.php
+++ b/tests/Unit/Constraints/JsonSameAsArrayTest.php
@@ -13,6 +13,22 @@ use PHPUnit\Framework\AssertionFailedError;
 class JsonSameAsArrayTest extends UnitTestCase
 {
     /**
+     * Asserts that if the expected array order is different that the json order that we succeed.
+     *
+     * @return void
+     */
+    public function testArrayOrderDoesntMatter(): void
+    {
+        $json = '{"abc": "xyz", "bcd": "yza"}';
+        $expected = ['bcd' => 'yza', 'abc' => 'xyz'];
+
+        $constraint = new JsonSameAsArray($expected);
+        $passes = $constraint->evaluate($json, '', true);
+
+        self::assertTrue($passes);
+    }
+
+    /**
      * Test to make sure if arrays match, constraint passes.
      *
      * @return void

--- a/tests/Unit/TestCases/UnitTestCase/AssertJsonEqualsStringFuzzilyTest.php
+++ b/tests/Unit/TestCases/UnitTestCase/AssertJsonEqualsStringFuzzilyTest.php
@@ -6,7 +6,6 @@ namespace Tests\Eonx\TestUtils\Unit\TestCases\UnitTestCase;
 use Eonx\TestUtils\TestCases\UnitTestCase;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\ExpectationFailedException;
-use SebastianBergmann\Comparator\ComparisonFailure;
 
 /**
  * @covers \Eonx\TestUtils\TestCases\UnitTestCase::assertJsonEqualsStringFuzzily

--- a/tests/Unit/TestCases/UnitTestCase/AssertJsonEqualsStringFuzzilyTest.php
+++ b/tests/Unit/TestCases/UnitTestCase/AssertJsonEqualsStringFuzzilyTest.php
@@ -5,6 +5,8 @@ namespace Tests\Eonx\TestUtils\Unit\TestCases\UnitTestCase;
 
 use Eonx\TestUtils\TestCases\UnitTestCase;
 use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\ExpectationFailedException;
+use SebastianBergmann\Comparator\ComparisonFailure;
 
 /**
  * @covers \Eonx\TestUtils\TestCases\UnitTestCase::assertJsonEqualsStringFuzzily
@@ -39,8 +41,8 @@ class AssertJsonEqualsStringFuzzilyTest extends UnitTestCase
         $json = '{"abc": "xyz", "date": "2019-10-10T01:04:45Z"}';
         $expected = ['xyz' => 'abc', 'date' => ':fuzzy:'];
 
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Failed asserting that two arrays are identical.');
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('Failed asserting that two arrays are equal.');
 
         self::assertJsonEqualsStringFuzzily($expected, $json);
     }

--- a/tests/Unit/TestCases/UnitTestCase/AssertResponseTest.php
+++ b/tests/Unit/TestCases/UnitTestCase/AssertResponseTest.php
@@ -39,7 +39,7 @@ class AssertResponseTest extends UnitTestCase
             'response' => new Response('{"abc": "xyz"}', 202, ['content-type' => 'application/json']),
             'expectedStatus' => 202,
             'expectedContent' => [],
-            'exception' => new AssertionFailedError('Failed asserting that two arrays are identical.')
+            'exception' => new AssertionFailedError('Failed asserting that two arrays are equal.')
         ];
 
         yield 'Response can be matched fuzzily' => [


### PR DESCRIPTION
This allows us to override the scalar comparisons when doing an assertEquals() on an array.

The goal is to be able to use it like this:

https://github.com/eonx-com/test-utils/pull/18/files#diff-e68d839523556ca76a6ea5beff58ae3cR75-R89

The JsonSameAsArray assertion has been modified to use this approach so that we dont care about array key order.